### PR TITLE
change: rework SpanId

### DIFF
--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -13,8 +13,6 @@
 
 use eaze_tracing_distributed as tracing_distributed;
 
-use rand::{self, Rng};
-
 mod honeycomb;
 mod span_id;
 mod trace_id;
@@ -54,14 +52,10 @@ pub fn current_dist_trace_ctx() -> Result<(TraceId, SpanId), TraceCtxError> {
 /// Specialized to the honeycomb.io-specific SpanId and TraceId provided by this crate.
 pub fn new_blackhole_telemetry_layer(
 ) -> TelemetryLayer<tracing_distributed::BlackholeTelemetry<SpanId, TraceId>, SpanId, TraceId> {
-    let instance_id: u64 = 0;
     TelemetryLayer::new(
         "honeycomb_blackhole_tracing_layer",
         tracing_distributed::BlackholeTelemetry::default(),
-        move |tracing_id| SpanId {
-            instance_id,
-            tracing_id,
-        },
+        move |tracing_id| SpanId { tracing_id },
     )
 }
 
@@ -72,14 +66,10 @@ pub fn new_honeycomb_telemetry_layer(
     service_name: &'static str,
     honeycomb_config: libhoney::Config,
 ) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
-    let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(
         service_name,
         HoneycombTelemetry::new(honeycomb_config, None),
-        move |tracing_id| SpanId {
-            instance_id,
-            tracing_id,
-        },
+        move |tracing_id| SpanId { tracing_id },
     )
 }
 
@@ -103,13 +93,9 @@ pub fn new_honeycomb_telemetry_layer_with_trace_sampling(
     honeycomb_config: libhoney::Config,
     sample_rate: u32,
 ) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
-    let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(
         service_name,
         HoneycombTelemetry::new(honeycomb_config, Some(sample_rate)),
-        move |tracing_id| SpanId {
-            instance_id,
-            tracing_id,
-        },
+        move |tracing_id| SpanId { tracing_id },
     )
 }

--- a/tracing-honeycomb/src/span_id.rs
+++ b/tracing-honeycomb/src/span_id.rs
@@ -1,14 +1,15 @@
+use std::convert::TryFrom;
 use std::fmt::{self, Display};
+use std::num::{NonZeroU64, ParseIntError, TryFromIntError};
 use std::str::FromStr;
 /// Unique Span identifier.
 ///
-/// Combines a span's `tracing::Id` with an instance identifier to avoid id collisions in distributed scenarios.
+/// Wraps a `tracing::span::Id` with a suitable parser.
 ///
 /// `Display` and `FromStr` are guaranteed to round-trip.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SpanId {
     pub(crate) tracing_id: tracing::span::Id,
-    pub(crate) instance_id: u64,
 }
 
 impl SpanId {
@@ -20,32 +21,48 @@ impl SpanId {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParseSpanIdError {
-    ParseIntError(std::num::ParseIntError),
-    FormatError,
+    ParseIntError(ParseIntError),
+    TryFromIntError(TryFromIntError),
+}
+
+impl Display for ParseSpanIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParseIntError(e) => write!(f, "{}", e),
+            Self::TryFromIntError(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<ParseIntError> for ParseSpanIdError {
+    fn from(err: ParseIntError) -> Self {
+        Self::ParseIntError(err)
+    }
+}
+
+impl From<TryFromIntError> for ParseSpanIdError {
+    fn from(err: TryFromIntError) -> Self {
+        Self::TryFromIntError(err)
+    }
 }
 
 impl FromStr for SpanId {
     type Err = ParseSpanIdError;
 
-    /// Parses a Span Id from a `{SPAN}-{INSTANCE}` u64 pair, such as `1234567890-1234567890`.
+    /// Parses a Span Id from a hex value.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iter = s.split('-');
-        let s1 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
-        let u1 = u64::from_str_radix(s1, 10).map_err(ParseSpanIdError::ParseIntError)?;
-        let s2 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
-        let u2 = u64::from_str_radix(s2, 10).map_err(ParseSpanIdError::ParseIntError)?;
+        let raw_id = u64::from_str_radix(s, 16)?;
+        let id = NonZeroU64::try_from(raw_id)?;
 
         Ok(SpanId {
-            tracing_id: tracing::Id::from_u64(u1),
-            instance_id: u2,
+            tracing_id: tracing::Id::from_non_zero_u64(id),
         })
     }
 }
 
 impl Display for SpanId {
-    /// Formats a Span Id as a `{SPAN}-{INSTANCE}` u64 pair, such as `1234567890-1234567890`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.tracing_id.into_u64(), self.instance_id)
+        write!(f, "{:x}", self.tracing_id.into_u64())
     }
 }
 
@@ -59,10 +76,9 @@ mod test {
     proptest! {
         #[test]
         // ua is [1..] and not [0..] because 0 is not a valid tracing::Id (tracing::from_u64 throws on 0)
-        fn span_id_round_trip(ua in 1u64.., ub in 1u64..) {
+        fn span_id_round_trip(ua in 1u64..) {
             let span_id = SpanId {
                 tracing_id: tracing::Id::from_u64(ua),
-                instance_id: ub,
             };
             let s = span_id.to_string();
             let res = SpanId::from_str(&s);


### PR DESCRIPTION
Instance ids appear unnecessary. Any span must already be associated with a trace, which has 128 bits (a very large space to avoid collisions). Given a span ids must only be unique in a given trace, 64 bits alone should be plenty. Also, honeycomb doesn't have any special way to represent full parallelism, the full span ids must be different anyways.

This also changes the SpanId formatting to be hex by default. The parser has also been update to parse in hex.