### PR TITLE
honeycomb: always send when no sampling is set

### DIFF
--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -54,7 +54,7 @@ impl HoneycombTelemetry {
         if let Some(sample_rate) = self.sample_rate {
             crate::deterministic_sampler::sample(sample_rate, trace_id)
         } else {
-            false
+            true
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eaze/tracing-honeycomb/issues/4

This bug was accidentally introduced in
https://github.com/eaze/tracing-honeycomb/pull/1/files#diff-a6d41a7f5e4676085d87156aedec476bd27839aa5c13dbba5ac4f91518ac06fdR57