### PR TITLE
AWS lambda instrumentation

### DIFF
--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -25,6 +25,8 @@ chrono = "0.4"
 parking_lot = { version = "0.11", optional = true }
 uuid = { version = "0.8", features = ["v4"] }
 sha-1 = "0.9"
+serde = "1"
+serde_json = "1"
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -182,7 +182,7 @@ impl Builder<LibhoneyReporter> {
 }
 
 impl<R: Reporter> Builder<R> {
-    /// Enables samling for the telemetry layer.
+    /// Enables sampling for the telemetry layer.
     ///
     /// The `sample_rate` on the `libhoney::Config` is different from this in an important way.
     /// `libhoney` samples `Event` data, which is individual spans on each trace.

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -12,11 +12,13 @@
 //! As a tracing layer, `TelemetryLayer` can be composed with other layers to provide stdout logging, filtering, etc.
 
 mod honeycomb;
+mod reporter;
 mod span_id;
 mod trace_id;
 mod visitor;
 
 pub use honeycomb::HoneycombTelemetry;
+pub use reporter::{LibhoneyReporter, Reporter, StdoutReporter};
 pub use span_id::SpanId;
 pub use trace_id::TraceId;
 #[doc(no_inline)]
@@ -24,6 +26,11 @@ pub use tracing_distributed::{TelemetryLayer, TraceCtxError};
 pub use visitor::HoneycombVisitor;
 
 pub(crate) mod deterministic_sampler;
+
+#[cfg(feature = "use_parking_lot")]
+use parking_lot::Mutex;
+#[cfg(not(feature = "use_parking_lot"))]
+use std::sync::Mutex;
 
 /// Register the current span as the local root of a distributed trace.
 ///
@@ -63,18 +70,24 @@ pub fn new_blackhole_telemetry_layer(
 pub fn new_honeycomb_telemetry_layer(
     service_name: &'static str,
     honeycomb_config: libhoney::Config,
-) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
+) -> TelemetryLayer<HoneycombTelemetry<LibhoneyReporter>, SpanId, TraceId> {
+    let reporter = libhoney::init(honeycomb_config);
+    // publishing requires &mut so just mutex-wrap it
+    // FIXME: may not be performant, investigate options (eg mpsc)
+    let reporter = Mutex::new(reporter);
+
     TelemetryLayer::new(
         service_name,
-        HoneycombTelemetry::new(honeycomb_config, None),
+        HoneycombTelemetry::new(reporter, None),
         move |tracing_id| SpanId { tracing_id },
     )
 }
 
 /// Construct a TelemetryLayer that publishes telemetry to honeycomb.io using the
-/// provided honeycomb config, and sample rate. This function differs from
-/// `new_honeycomb_telemetry_layer` and the `sample_rate` on the
-/// `libhoney::Config` there in an important way. `libhoney` samples `Event`
+/// provided honeycomb config, and sample rate.
+///
+/// This function differs from `new_honeycomb_telemetry_layer` and the `sample_rate`
+/// on the `libhoney::Config` there in an important way. `libhoney` samples `Event`
 /// data, which is individual spans on each trace. This means that using the
 /// sampling logic in libhoney may result in missing event data or incomplete
 /// traces. Calling this function provides trace-level sampling, meaning sampling
@@ -90,10 +103,109 @@ pub fn new_honeycomb_telemetry_layer_with_trace_sampling(
     service_name: &'static str,
     honeycomb_config: libhoney::Config,
     sample_rate: u32,
-) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
+) -> TelemetryLayer<HoneycombTelemetry<LibhoneyReporter>, SpanId, TraceId> {
+    let reporter = libhoney::init(honeycomb_config);
+    // publishing requires &mut so just mutex-wrap it
+    // FIXME: may not be performant, investigate options (eg mpsc)
+    let reporter = Mutex::new(reporter);
+
     TelemetryLayer::new(
         service_name,
-        HoneycombTelemetry::new(honeycomb_config, Some(sample_rate)),
+        HoneycombTelemetry::new(reporter, Some(sample_rate)),
         move |tracing_id| SpanId { tracing_id },
     )
+}
+
+/// Builds Honeycomb Telemetry with custom configuration values.
+///
+/// Methods can be chained in order to set the configuration values. The
+/// TelemetryLayer is constructed by calling [`build`].
+///
+/// New instances of `Builder` are obtained via [`Builder::new_libhoney`]
+/// or [`Builder::new_stdout`].
+///
+/// [`Builder::new_stdout`] is useful when instrumenting e.g. AWS Lambda functions.
+/// See more at [AWS Lambda Instrumentation]. For almost all other use cases you are probably
+/// looking for [`Builder::new_libhoney`].
+///
+/// [`build`]: method@Self::build
+/// [`Builder::new_stdout`]: method@Builder::<StdoutReporter>::new_stdout
+/// [`Builder::new_libhoney`]: method@Builder::<LibhoneyReporter>::new_libhoney
+/// [AWS Lambda Instrumentation]: https://docs.honeycomb.io/getting-data-in/integrations/aws/aws-lambda/
+#[derive(Debug)]
+pub struct Builder<R> {
+    reporter: R,
+    sample_rate: Option<u32>,
+    service_name: &'static str,
+}
+
+impl Builder<StdoutReporter> {
+    /// Returns a new `Builder` that reports data to stdout
+    pub fn new_stdout(service_name: &'static str) -> Self {
+        Self {
+            reporter: StdoutReporter,
+            sample_rate: None,
+            service_name,
+        }
+    }
+}
+
+impl Builder<LibhoneyReporter> {
+    /// Returns a new `Builder` that reports data to a [`libhoney::Client`]
+    pub fn new_libhoney(service_name: &'static str, config: libhoney::Config) -> Self {
+        let reporter = libhoney::init(config);
+
+        // Handle the libhoney response channel by consuming and ignoring messages. This prevents a
+        // deadlock because the responses() channel is bounded and gains an item for every event
+        // emitted.
+        let responses = reporter.responses();
+        std::thread::spawn(move || {
+            loop {
+                if responses.recv().is_err() {
+                    // If we receive an error, the channel is empty & disconnected. No need to keep
+                    // this thread around.
+                    break;
+                }
+            }
+        });
+
+        // publishing requires &mut so just mutex-wrap it
+        // FIXME: may not be performant, investigate options (eg mpsc)
+        let reporter = Mutex::new(reporter);
+
+        Self {
+            reporter,
+            sample_rate: None,
+            service_name,
+        }
+    }
+}
+
+impl<R: Reporter> Builder<R> {
+    /// Enables samling for the telemetry layer.
+    ///
+    /// The `sample_rate` on the `libhoney::Config` is different from this in an important way.
+    /// `libhoney` samples `Event` data, which is individual spans on each trace.
+    /// This means that using the sampling logic in libhoney may result in missing
+    /// event data or incomplete traces.
+    /// Calling this function provides trace-level sampling, meaning sampling
+    /// decisions are based on a modulo of the traceID, and events in a single trace
+    /// will not be sampled differently. If the trace is sampled, then all spans
+    /// under it will be sent to honeycomb. If a trace is not sampled, no spans or
+    /// events under it will be sent. When using this trace-level sampling,
+    /// when using a [`LibhoneyReporter`] the `sample_rate` parameter on the
+    /// [`libhoney::Config`] should be set to 1, which is the default.
+    pub fn with_trace_sampling(mut self, sample_rate: u32) -> Self {
+        self.sample_rate.replace(sample_rate);
+        self
+    }
+
+    /// Constructs the configured `TelemetryLayer`
+    pub fn build(self) -> TelemetryLayer<HoneycombTelemetry<R>, SpanId, TraceId> {
+        TelemetryLayer::new(
+            self.service_name,
+            HoneycombTelemetry::new(self.reporter, self.sample_rate),
+            move |tracing_id| SpanId { tracing_id },
+        )
+    }
 }

--- a/tracing-honeycomb/src/reporter.rs
+++ b/tracing-honeycomb/src/reporter.rs
@@ -1,0 +1,47 @@
+use chrono::{DateTime, Utc};
+use libhoney::FieldHolder;
+use std::collections::HashMap;
+
+#[cfg(feature = "use_parking_lot")]
+use parking_lot::Mutex;
+#[cfg(not(feature = "use_parking_lot"))]
+use std::sync::Mutex;
+
+/// Reports data to some backend
+pub trait Reporter {
+    /// Reports data to the backend
+    fn report_data(&self, data: HashMap<String, libhoney::Value>, timestamp: DateTime<Utc>);
+}
+
+/// Reporter that sends events and spans to a [`libhoney::Client`]
+pub type LibhoneyReporter = Mutex<libhoney::Client<libhoney::transmission::Transmission>>;
+impl Reporter for LibhoneyReporter {
+    fn report_data(&self, data: HashMap<String, libhoney::Value>, timestamp: DateTime<Utc>) {
+        // succeed or die. failure is unrecoverable (mutex poisoned)
+        #[cfg(not(feature = "use_parking_lot"))]
+        let mut reporter = self.lock().unwrap();
+        #[cfg(feature = "use_parking_lot")]
+        let mut reporter = self.lock();
+
+        let mut ev = reporter.new_event();
+        ev.add(data);
+        ev.set_timestamp(timestamp);
+        let res = ev.send(&mut reporter);
+        if let Err(err) = res {
+            // unable to report telemetry (buffer full) so log msg to stderr
+            // TODO: figure out strategy for handling this (eg report data loss event)
+            eprintln!("error sending event to honeycomb, {:?}", err);
+        }
+    }
+}
+
+/// Reporter that sends events and spans to stdout
+#[derive(Debug, Clone, Copy)]
+pub struct StdoutReporter;
+impl Reporter for StdoutReporter {
+    fn report_data(&self, data: HashMap<String, libhoney::Value>, _timestamp: DateTime<Utc>) {
+        if let Ok(data) = serde_json::to_string(&data) {
+            println!("{}", data);
+        }
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/eaze/tracing-honeycomb/issues/5



# Questions
1. Right now we ignore messages where serialization fails:
```rust
if let Ok(data) = serde_json::to_string(&data) {
      println!("{}", data);
}
```
What should the default behaviour be?

---
2. We now pull in serde and serde_json even if you need it or not.
This is already in the dependency tree, so maybe it's fine?