### PR TITLE
Update dependencies to tracing-subscriber 0.3

### DIFF
--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -18,7 +18,7 @@ use_parking_lot = ["parking_lot"]
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.3"
 itertools = "0.9"
 parking_lot = { version = "0.11", optional = true }
 

--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -179,7 +179,7 @@ where
     V: 'static + tracing::field::Visit + Send + Sync,
     T: 'static + Telemetry<Visitor = V, TraceId = TraceId, SpanId = SpanId>,
 {
-    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
+    fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("span data not found during new_span");
         let mut extensions_mut = span.extensions_mut();
         extensions_mut.insert(SpanInitAt::new());

--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -237,7 +237,7 @@ where
                         parent_id: Some(self.trace_ctx_registry.promote_span_id(parent_id)),
                         initialized_at,
                         meta: event.metadata(),
-                        service_name: &self.service_name,
+                        service_name: self.service_name,
                         values: visitor,
                     };
 

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1"
 [dev-dependencies]
 tracing-attributes = "0.1.5"
 futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.3.0"
 tokio = { version = "0.2", features = ["full"] }
 tracing-futures = "0.2.1"
 proptest = "0.9.5"


### PR DESCRIPTION
I ran into a problem when using the current version of tracing-appender with a custom telemetry layer built on tracing-distributed since they renamed the associated function `new_span`.

Tests for both crates with default config pass with this update, but I'm not a user of honeycomb, so I have not tested further than that.

Feedback is appreciated.