### PR TITLE
impl Error for TraceCtxError and ParseSpanIdError

### DIFF
--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -237,7 +237,7 @@ where
                         parent_id: Some(self.trace_ctx_registry.promote_span_id(parent_id)),
                         initialized_at,
                         meta: event.metadata(),
-                        service_name: &self.service_name,
+                        service_name: self.service_name,
                         values: visitor,
                     };
 

--- a/tracing-distributed/src/trace.rs
+++ b/tracing-distributed/src/trace.rs
@@ -87,6 +87,21 @@ pub enum TraceCtxError {
     NoParentNodeHasTraceCtx,
 }
 
+impl std::fmt::Display for TraceCtxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use TraceCtxError::*;
+        write!(f, "{}",
+            match self {
+                TelemetryLayerNotRegistered => "`TelemetryLayer` is not a registered subscriber of the current Span",
+                RegistrySubscriberNotRegistered => "no `tracing_subscriber::Registry` is a registered subscriber of the current Span",
+                NoEnabledSpan => "the span is not enabled with an associated subscriber",
+                NoParentNodeHasTraceCtx => "unable to evaluate trace context; assert `register_dist_tracing_root` is called in some parent span",
+            })
+    }
+}
+
+impl std::error::Error for TraceCtxError {}
+
 /// A `Span` holds ready-to-publish information gathered during the lifetime of a `tracing::Span`.
 #[derive(Debug, Clone)]
 pub struct Span<Visitor, SpanId, TraceId> {

--- a/tracing-honeycomb/src/span_id.rs
+++ b/tracing-honeycomb/src/span_id.rs
@@ -46,6 +46,8 @@ impl From<TryFromIntError> for ParseSpanIdError {
     }
 }
 
+impl std::error::Error for ParseSpanIdError {}
+
 impl FromStr for SpanId {
     type Err = ParseSpanIdError;
 


### PR DESCRIPTION
By implementing `std::error::Error` it's possible to use them with `anyhow` for example. Also, from my understanding, it's expected behavior for errors anyway.

I tried to use a shorter, yet still understandable, version of the docstrings for the error messages. If you'd prefer something different, feel free to change or let me know what to put.