### PR TITLE
tracing-distributed@0.4.0, tracing-honeycomb@0.4.3 - tracing-subscriber 0.3 compatibility + Error impls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: docs
-      run: cargo clean && cargo +nightly doc --no-deps
+      run: cargo +nightly doc --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
     - name: update clippy
       run: rustup toolchain update stable
 
-    - name: install nightly
-      run: rustup toolchain install nightly
-
     - name: clippy
       run: cargo clippy --workspace --all-targets
 
@@ -51,4 +48,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: docs
-      run: cargo +nightly doc --no-deps
+      run: cargo doc --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: docs
-      run: cargo +nightly doc --no-deps
+      run: cargo clean && cargo +nightly doc --no-deps

--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -18,7 +18,7 @@ use_parking_lot = ["parking_lot"]
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.3"
 itertools = "0.9"
 parking_lot = { version = "0.11", optional = true }
 

--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-distributed"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
     "Inanna Malick <inanna@recursion.wtf>",
     "Jeremiah Senkpiel <fishrock123@rocketmail.com>"

--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -179,7 +179,7 @@ where
     V: 'static + tracing::field::Visit + Send + Sync,
     T: 'static + Telemetry<Visitor = V, TraceId = TraceId, SpanId = SpanId>,
 {
-    fn new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
+    fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("span data not found during new_span");
         let mut extensions_mut = span.extensions_mut();
         extensions_mut.insert(SpanInitAt::new());

--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -237,7 +237,7 @@ where
                         parent_id: Some(self.trace_ctx_registry.promote_span_id(parent_id)),
                         initialized_at,
                         meta: event.metadata(),
-                        service_name: &self.service_name,
+                        service_name: self.service_name,
                         values: visitor,
                     };
 

--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -237,7 +237,7 @@ where
                         parent_id: Some(self.trace_ctx_registry.promote_span_id(parent_id)),
                         initialized_at,
                         meta: event.metadata(),
-                        service_name: self.service_name,
+                        service_name: &self.service_name,
                         values: visitor,
                     };
 

--- a/tracing-distributed/src/trace.rs
+++ b/tracing-distributed/src/trace.rs
@@ -87,6 +87,21 @@ pub enum TraceCtxError {
     NoParentNodeHasTraceCtx,
 }
 
+impl std::fmt::Display for TraceCtxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use TraceCtxError::*;
+        write!(f, "{}",
+            match self {
+                TelemetryLayerNotRegistered => "`TelemetryLayer` is not a registered subscriber of the current Span",
+                RegistrySubscriberNotRegistered => "no `tracing_subscriber::Registry` is a registered subscriber of the current Span",
+                NoEnabledSpan => "the span is not enabled with an associated subscriber",
+                NoParentNodeHasTraceCtx => "unable to evaluate trace context; assert `register_dist_tracing_root` is called in some parent span",
+            })
+    }
+}
+
+impl std::error::Error for TraceCtxError {}
+
 /// A `Span` holds ready-to-publish information gathered during the lifetime of a `tracing::Span`.
 #[derive(Debug, Clone)]
 pub struct Span<Visitor, SpanId, TraceId> {

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-honeycomb"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     "Inanna Malick <inanna@recursion.wtf>",
     "Jeremiah Senkpiel <fishrock123@rocketmail.com>"
@@ -18,7 +18,7 @@ use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-tracing-distributed =  { path = "../tracing-distributed", version = "0.3" }
+tracing-distributed =  { path = "../tracing-distributed", version = ">= 0.3, < 0.5" }
 libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4"

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1"
 [dev-dependencies]
 tracing-attributes = "0.1.5"
 futures-preview = { version = "0.3.0-alpha.19", features = ["compat"] }
-tracing-subscriber = "0.2.0"
+tracing-subscriber = "0.3.0"
 tokio = { version = "0.2", features = ["full"] }
 tracing-futures = "0.2.1"
 proptest = "0.9.5"

--- a/tracing-honeycomb/src/span_id.rs
+++ b/tracing-honeycomb/src/span_id.rs
@@ -46,6 +46,8 @@ impl From<TryFromIntError> for ParseSpanIdError {
     }
 }
 
+impl std::error::Error for ParseSpanIdError {}
+
 impl FromStr for SpanId {
     type Err = ParseSpanIdError;
 


### PR DESCRIPTION
This PR takes #12 and #13 and packages them up into a release branch:

- Updates tracing-subscriber to v3 in tracing-distributed (#12)
- Updates arguments passed to trace::Event in tracing-distributed (#12, #13)
- Updates tracing-honeycomb to accept tracing-distributed v0.3 or v0.4 (both are compatible)
- Implements Error trait for TraceCtxError and ParseSpanIdError (#13)
- Implements Display trait for TraceCtxError
- Bumps tracing-subscriber to v0.4.0 (breaking)
- Bumps tracing-honeycomb to v0.4.3 (additive)

A general release plan taking preroll and our apps into account is in the comments.
