### PR TITLE
Changelogs for tracing-distrubuted @ 0.4.0 and tracing-honeycomb @ 0.4.3

### DIFF
--- a/tracing-distributed/Changelog.md
+++ b/tracing-distributed/Changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2021-12-27
+
+### Deps
+
+- Update to tracing-subscriber 0.3
+
+### Additions
+
+- Implemented Display and Error for `TraceCtxError`
+
 ## [0.3.1] - 2021-04-15
 
 ### Fixes

--- a/tracing-honeycomb/Changelog.md
+++ b/tracing-honeycomb/Changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2021-12-27
+
+### Deps
+
+- Update the acceptable range for tracing-distributed to include 0.4
+
+### Additions
+
+- Implemented Error for `ParseSpanIdError`
+
 ## [0.4.2] - 2021-06-28
 
 ### Fixes


### PR DESCRIPTION
I somehow missed that Jeremiah was maintaining a changelog! It looks like he was also tagging releases.

My plan is to merge this and tag the SHAs that actually went out with the releases, and accept that the changelog was (erroneously!) not updated for those releases.

Re: the commit messages, Jeremiah was being good at writing extended commit messages with a partially embedded changelog and I want to keep that tradition going. But was he using a toolchain for it? Maybe a cli tool? If so, maybe we can do something fun with bots to keep the history smooth? Dunno. I like the commit history but I don't like pushing to latest.