### PR TITLE
Remove SpanInitAt from Span

### DIFF
--- a/tracing-distributed/src/telemetry_layer.rs
+++ b/tracing-distributed/src/telemetry_layer.rs
@@ -182,7 +182,6 @@ where
     fn on_new_span(&self, attrs: &Attributes, id: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("span data not found during new_span");
         let mut extensions_mut = span.extensions_mut();
-        extensions_mut.insert(SpanInitAt::new());
 
         let mut visitor: V = self.telemetry.mk_visitor();
         attrs.record(&mut visitor);
@@ -268,9 +267,6 @@ where
             let visitor: V = extensions_mut
                 .remove()
                 .expect("should be present on all spans");
-            let SpanInitAt(initialized_at) = extensions_mut
-                .remove()
-                .expect("should be present on all spans");
 
             let completed_at = SystemTime::now();
 
@@ -285,7 +281,6 @@ where
                 id: self.trace_ctx_registry.promote_span_id(id),
                 meta: span.metadata(),
                 parent_id,
-                initialized_at,
                 trace_id: trace_ctx.trace_id,
                 completed_at,
                 service_name: self.service_name,
@@ -317,15 +312,8 @@ where
 // TODO: delete?
 struct LazyTraceCtx<SpanId, TraceId>(TraceCtx<SpanId, TraceId>);
 
-struct SpanInitAt(SystemTime);
 
-impl SpanInitAt {
-    fn new() -> Self {
-        let initialized_at = SystemTime::now();
 
-        Self(initialized_at)
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/tracing-distributed/src/trace.rs
+++ b/tracing-distributed/src/trace.rs
@@ -112,7 +112,6 @@ pub struct Span<Visitor, SpanId, TraceId> {
     /// optional parent span id
     pub parent_id: Option<SpanId>,
     /// UTC time at which this span was initialized
-    pub initialized_at: SystemTime,
     /// `chrono::Duration` elapsed between the time this span was initialized and the time it was completed
     pub completed_at: SystemTime,
     /// `tracing::Metadata` for this span


### PR DESCRIPTION
This is a simple sketch removing `SpanInitAt` from span metadata.

It's necessary when allowing the use of multiple telemetry layers since the values collide in `tracing-subscriber::registry::ExtensionsMut::insert` and results in a panic at runtime.