### PR TITLE
Add `tracing-otlp` subcrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 honeycomb.key
+**~

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tracing-otlp/opentelemetry-proto"]
+	path = tracing-otlp/opentelemetry-proto
+	url = git@github.com:open-telemetry/opentelemetry-proto.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tracing-otlp/opentelemetry-proto"]
 	path = tracing-otlp/opentelemetry-proto
-	url = git@github.com:open-telemetry/opentelemetry-proto.git
+	url = https://github.com/open-telemetry/opentelemetry-proto.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "tracing-distributed",
     "tracing-honeycomb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
     "tracing-distributed",
     "tracing-honeycomb",
+    "tracing-otlp"
 ]

--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -13,14 +13,12 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-use_parking_lot = ["parking_lot"]
 
 [dependencies]
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.3"
 itertools = "0.9"
-parking_lot = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -16,8 +16,8 @@ readme = "README.md"
 use_parking_lot = ["parking_lot"]
 
 [dependencies]
-tracing = "0.1.12"
-tracing-core = "0.1.9"
+tracing = "0.1"
+tracing-core = "0.1"
 tracing-subscriber = "0.3"
 itertools = "0.9"
 parking_lot = { version = "0.11", optional = true }

--- a/tracing-distributed/src/trace.rs
+++ b/tracing-distributed/src/trace.rs
@@ -107,6 +107,8 @@ impl std::error::Error for TraceCtxError {}
 pub struct Span<Visitor, SpanId, TraceId> {
     /// id identifying this span
     pub id: SpanId,
+    /// Name of the span
+    pub name: String,
     /// `TraceId` identifying the trace to which this span belongs
     pub trace_id: TraceId,
     /// optional parent span id
@@ -126,8 +128,8 @@ pub struct Span<Visitor, SpanId, TraceId> {
 /// An `Event` holds ready-to-publish information derived from a `tracing::Event`.
 #[derive(Clone, Debug)]
 pub struct Event<Visitor, SpanId, TraceId> {
-    /// `TraceId` identifying the trace to which this event belongs
-    pub trace_id: TraceId,
+    /// `TraceId` identifying the trace to which this event belongs, it it is part of a trace.
+    pub trace_id: Option<TraceId>,
     /// optional parent span id
     pub parent_id: Option<SpanId>,
     /// UTC time at which this event was initialized

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -16,8 +16,8 @@ readme = "README.md"
 use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
 
 [dependencies]
-tracing = "0.1.12"
-tracing-core = "0.1.9"
+tracing = "0.1"
+tracing-core = "0.1"
 tracing-distributed =  { path = "../tracing-distributed", version = ">= 0.3, < 0.5" }
 libhoney-rust = "0.1.3"
 rand = "0.7"

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
+use_parking_lot = ["parking_lot"]
 
 [dependencies]
 tracing = "0.1"

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -20,7 +20,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-distributed =  { path = "../tracing-distributed", version = ">= 0.3, < 0.5" }
 libhoney-rust = "0.1.3"
-rand = "0.7"
+rand = "0.8"
 chrono = "0.4"
 parking_lot = { version = "0.11", optional = true }
 uuid = { version = "0.8", features = ["v4"] }

--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -45,17 +45,20 @@ impl<R: Reporter> Telemetry for HoneycombTelemetry<R> {
         Default::default()
     }
 
-    fn report_span(&self, span: Span<Self::Visitor, Self::SpanId, Self::TraceId>) {
+    fn report_span(
+        &self,
+        span: Span<Self::Visitor, Self::SpanId, Self::TraceId>,
+        events: Vec<Event<Self::Visitor, Self::SpanId, Self::TraceId>>,
+    ) {
         if self.should_report(&span.trace_id) {
+            for event in events {
+                let (data, timestamp) = event_to_values(event);
+                self.report_data(data, timestamp);
+            }
             let (data, timestamp) = span_to_values(span);
             self.report_data(data, timestamp);
         }
     }
 
-    fn report_event(&self, event: Event<Self::Visitor, Self::SpanId, Self::TraceId>) {
-        if self.should_report(&event.trace_id) {
-            let (data, timestamp) = event_to_values(event);
-            self.report_data(data, timestamp);
-        }
-    }
+    fn report_event(&self, _event: Event<Self::Visitor, Self::SpanId, Self::TraceId>) {}
 }

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -25,6 +25,8 @@ pub use trace_id::TraceId;
 pub use tracing_distributed::{TelemetryLayer, TraceCtxError};
 pub use visitor::HoneycombVisitor;
 
+pub use libhoney::{client::Options, Config};
+
 pub(crate) mod deterministic_sampler;
 
 #[cfg(feature = "use_parking_lot")]

--- a/tracing-honeycomb/src/visitor.rs
+++ b/tracing-honeycomb/src/visitor.rs
@@ -73,7 +73,10 @@ pub(crate) fn event_to_values(
         // magic honeycomb string (trace.trace_id)
         "trace.trace_id".to_string(),
         // using explicit trace id passed in from ctx (req'd for lazy eval)
-        json!(event.trace_id.to_string()),
+        event
+            .trace_id
+            .map(|tid| json!(tid.to_string()))
+            .unwrap_or(json!(null)),
     );
 
     values.insert(

--- a/tracing-otlp/Cargo.toml
+++ b/tracing-otlp/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { version = "1.10", features = ["v4"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"
+procspawn = "1.0"
 
 [build-dependencies]
 prost-build = "0.13"

--- a/tracing-otlp/Cargo.toml
+++ b/tracing-otlp/Cargo.toml
@@ -12,6 +12,7 @@ prost = "0.13"
 ureq = "2.10"
 url = "2.5"
 uuid = { version = "1.10", features = ["v4"] }
+rand = "0.8"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/tracing-otlp/Cargo.toml
+++ b/tracing-otlp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tracing-otlp"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tracing = "0.1"
+tracing-distributed  = { path = "../tracing-distributed" }
+prost = "0.12"
+ureq = "2.10"
+url = "2.5"
+uuid = { version = "1.10", features = ["v4"] }
+
+[dev-dependencies]
+tracing-subscriber = "0.3"
+
+[build-dependencies]
+prost-build = "0.13"

--- a/tracing-otlp/Cargo.toml
+++ b/tracing-otlp/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 tracing-distributed  = { path = "../tracing-distributed" }
-prost = "0.12"
+prost = "0.13"
 ureq = "2.10"
 url = "2.5"
 uuid = { version = "1.10", features = ["v4"] }

--- a/tracing-otlp/build.rs
+++ b/tracing-otlp/build.rs
@@ -1,0 +1,10 @@
+use std::io::Result;
+fn main() -> Result<()> {
+    println!("cargo::rerun-if-changed=opentelemetry-proto/");
+
+    prost_build::compile_protos(
+        &["opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto"],
+        &["opentelemetry-proto"],
+    )?;
+    Ok(())
+}

--- a/tracing-otlp/examples/multi-process.rs
+++ b/tracing-otlp/examples/multi-process.rs
@@ -1,0 +1,49 @@
+//! Multi-process example connecting to a locally running OTLP server. To test with Jaeger, first run:
+//! ```
+//! docker run --rm --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.61.0
+//! ```
+
+use std::{thread, time::Duration};
+
+use tracing::{event, span, Level};
+use tracing_otlp::{current_dist_trace_ctx, register_dist_tracing_root, Builder, TraceId};
+use tracing_subscriber::layer::SubscriberExt;
+
+pub fn main() {
+    procspawn::init();
+
+    init_tracing();
+
+    span!(Level::INFO, "Main process").in_scope(|| {
+        register_dist_tracing_root(TraceId::new(), None).unwrap();
+        for i in 0..5 {
+            let ctx = current_dist_trace_ctx().unwrap();
+            procspawn::spawn((ctx.0 .0, ctx.1 .0, i), |(trace_id, span_id, i)| {
+                init_tracing();
+
+                span!(Level::INFO, "Subprocess", i = i).in_scope(|| {
+                    register_dist_tracing_root(trace_id.into(), Some(span_id.into())).unwrap();
+                    span!(Level::INFO, "Subprocess child", i = i).in_scope(|| {
+                        event!(Level::INFO, i, "event");
+                        thread::sleep(Duration::from_millis(50))
+                    });
+                });
+                thread::sleep(Duration::from_secs(3))
+            });
+        }
+        thread::sleep(Duration::from_millis(100))
+    });
+    thread::sleep(Duration::from_secs(3))
+}
+
+pub fn init_tracing() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry().with(
+            Builder::new()
+                .service_name("test".to_string())
+                .build("http://127.0.0.1:4318")
+                .unwrap(),
+        ),
+    )
+    .unwrap();
+}

--- a/tracing-otlp/examples/simple.rs
+++ b/tracing-otlp/examples/simple.rs
@@ -1,0 +1,44 @@
+//! Example connecting to a locally running OTLP server. To test with Jaeger, first run:
+//! ```
+//! docker run --rm --name jaeger -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one:1.61.0
+//! ```
+
+use std::{thread, time::Duration};
+
+pub use tracing;
+use tracing::{span, Level};
+use tracing_otlp::{current_dist_trace_ctx, register_dist_tracing_root, Builder, TraceId};
+pub use tracing_subscriber;
+use tracing_subscriber::layer::SubscriberExt;
+
+pub fn main() {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry().with(
+            Builder::new()
+                .service_name("test".to_string())
+                .build("http://127.0.0.1:4318")
+                .unwrap(),
+        ),
+    )
+    .unwrap();
+
+    span!(Level::INFO, "Main thread").in_scope(|| {
+        register_dist_tracing_root(TraceId::new(), None).unwrap();
+
+        for i in 0..5 {
+            let ctx = current_dist_trace_ctx().unwrap();
+            thread::spawn(move || {
+                thread::sleep(Duration::from_secs(2));
+                span!(Level::INFO, "Child thread", i = i).in_scope(|| {
+                    register_dist_tracing_root(ctx.0, Some(ctx.1)).unwrap();
+                    thread::sleep(Duration::from_secs(3));
+                })
+            });
+        }
+
+        thread::sleep(Duration::from_secs(1));
+    });
+
+    // Sleep to give worker a chance to send all traces
+    thread::sleep(Duration::from_secs(6));
+}

--- a/tracing-otlp/src/builder.rs
+++ b/tracing-otlp/src/builder.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use tracing_distributed::TelemetryLayer;
+
+use crate::{prost::common::v1::any_value::Value, Otlp, SpanId, TraceId};
+
+/// Builder for the [`crate::Otlp`] `tracing` layer.
+///
+/// Use the [`Builder`] in order to set configuration for the layer and its endpoint.
+pub struct Builder {
+    send_interval: Duration,
+    resource_attributes: Vec<(String, Value)>,
+    headers: Vec<(String, String)>,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            send_interval: Duration::from_secs(1),
+            resource_attributes: Default::default(),
+            headers: Default::default(),
+        }
+    }
+}
+
+impl Builder {
+    pub fn new() -> Builder {
+        Self::default()
+    }
+
+    /// Configures the interval at which traces are reported to the OTLP endpoint
+    pub fn send_interval(mut self, interval: Duration) -> Self {
+        self.send_interval = interval;
+        self
+    }
+
+    /// Sets the name of this service.
+    ///
+    /// See: [https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name]
+    pub fn service_name(mut self, service_name: String) -> Self {
+        self.resource_attributes
+            .push(("service.name".to_string(), service_name.into()));
+        self
+    }
+
+    /// Adds an attribute for this OpenTelemetry resource.
+    ///
+    /// This may be an attribute such as rust version, program version, MAC address, etc.
+    pub fn resource_attribute(mut self, key: String, value: impl Into<Value>) -> Self {
+        self.resource_attributes.push((key, value.into()));
+        self
+    }
+
+    /// Sets the HTTP headers to be added to OTLP requests.
+    ///
+    /// The headers are given in the form of a tuple, with the first value
+    /// the key and the second the value.
+    pub fn http_headers(mut self, headers: Vec<(String, String)>) -> Self {
+        self.headers = headers;
+        self
+    }
+
+    /// Builds a [`TelemetryLayer`] based on [`Otlp`] the settings provided.
+    ///
+    /// The `endpoint` given should be an HTTP URL.
+    ///
+    /// # Examples
+    /// ```
+    /// Builder::new().build("http://127.0.0.1:4318");
+    /// ```
+    pub fn build(
+        self,
+        endpoint: &str,
+    ) -> Result<TelemetryLayer<Otlp, SpanId, TraceId>, url::ParseError> {
+        Ok(TelemetryLayer::new(
+            "",
+            Otlp::new(
+                endpoint,
+                self.send_interval,
+                self.resource_attributes,
+                self.headers,
+            )?,
+            move |tracing_id| SpanId(tracing_id.into_u64()),
+        ))
+    }
+}

--- a/tracing-otlp/src/builder.rs
+++ b/tracing-otlp/src/builder.rs
@@ -1,5 +1,6 @@
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use tracing_distributed::TelemetryLayer;
 
 use crate::{prost::common::v1::any_value::Value, Otlp, SpanId, TraceId};
@@ -72,6 +73,7 @@ impl Builder {
         self,
         endpoint: &str,
     ) -> Result<TelemetryLayer<Otlp, SpanId, TraceId>, url::ParseError> {
+        let rng = Mutex::new(StdRng::from_entropy());
         Ok(TelemetryLayer::new(
             "",
             Otlp::new(
@@ -80,7 +82,7 @@ impl Builder {
                 self.resource_attributes,
                 self.headers,
             )?,
-            move |tracing_id| SpanId(tracing_id.into_u64()),
+            move |_| SpanId(rng.lock().unwrap().gen()),
         ))
     }
 }

--- a/tracing-otlp/src/id.rs
+++ b/tracing-otlp/src/id.rs
@@ -1,0 +1,47 @@
+/// Unique Span identifier.
+///
+/// Wraps a `u64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SpanId(pub u64);
+
+impl From<u64> for SpanId {
+    fn from(value: u64) -> Self {
+        SpanId(value)
+    }
+}
+
+impl From<SpanId> for u64 {
+    fn from(value: SpanId) -> u64 {
+        value.0
+    }
+}
+
+/// Uniquely identifies a single distributed trace.
+///
+/// Wraps a u128, and can be generated new from a UUID V4.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TraceId(pub u128);
+
+impl Default for TraceId {
+    fn default() -> Self {
+        Self(uuid::Uuid::new_v4().as_u128())
+    }
+}
+
+impl TraceId {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl From<u128> for TraceId {
+    fn from(value: u128) -> Self {
+        TraceId(value)
+    }
+}
+
+impl From<TraceId> for u128 {
+    fn from(value: TraceId) -> u128 {
+        value.0
+    }
+}

--- a/tracing-otlp/src/lib.rs
+++ b/tracing-otlp/src/lib.rs
@@ -110,8 +110,8 @@ impl Telemetry for Otlp {
             .collect();
 
         let span = Span {
-            trace_id: span.trace_id.0.to_le_bytes().to_vec(),
-            span_id: span.id.0.to_le_bytes().to_vec(),
+            trace_id: span.trace_id.0.to_be_bytes().to_vec(),
+            span_id: span.id.0.to_be_bytes().to_vec(),
             trace_state: "".to_string(),
             parent_span_id: span
                 .parent_id

--- a/tracing-otlp/src/lib.rs
+++ b/tracing-otlp/src/lib.rs
@@ -1,0 +1,151 @@
+//! This crate provides a `tracing` implementation for the OpenTelemetry protocol (OTLP),
+//! specifically on top of http/protobuf. It is based on `distributed-tracing` in order
+//! to allow for multi-process tracing.
+
+use std::{
+    str::FromStr,
+    sync::mpsc::{channel, Sender},
+    thread::{self},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use prost::{common::v1::any_value::Value, trace::v1::span};
+use tracing_distributed::{Telemetry, TraceCtxError};
+use url::Url;
+use worker::Worker;
+
+use crate::prost::trace::v1::Span;
+
+pub use builder::Builder;
+pub use id::SpanId;
+pub use id::TraceId;
+pub use visitor::Visitor;
+
+mod builder;
+mod id;
+
+pub mod prost;
+mod visitor;
+mod worker;
+
+/// Register the current span as the local root of a distributed trace.
+///
+/// Specialized to the OTLP SpanId and TraceId provided by this crate.
+pub fn register_dist_tracing_root(
+    trace_id: TraceId,
+    remote_parent_span: Option<SpanId>,
+) -> Result<(), TraceCtxError> {
+    tracing_distributed::register_dist_tracing_root(trace_id, remote_parent_span)
+}
+
+/// Retrieve the distributed trace context associated with the current span.
+///
+/// Returns the `TraceId`, if any, that the current span is associated with along with
+/// the `SpanId` belonging to the current span.
+///
+/// Specialized to the OTLP SpanId and TraceId provided by this crate.
+pub fn current_dist_trace_ctx() -> Result<(TraceId, SpanId), TraceCtxError> {
+    tracing_distributed::current_dist_trace_ctx()
+}
+
+/// OpenTelemetry protocol implementation of [`Telemetry`]. Use [`Builder`] to instantiate this.
+pub struct Otlp {
+    tx: Sender<Span>,
+}
+
+impl Otlp {
+    pub(crate) fn new(
+        endpoint: &str,
+        send_interval: Duration,
+        resource_attributes: Vec<(String, Value)>,
+        http_headers: Vec<(String, String)>,
+    ) -> Result<Self, url::ParseError> {
+        let (tx, rx) = channel();
+
+        let endpoint = Url::from_str(endpoint)?;
+
+        let mut worker = Worker::new(
+            send_interval,
+            endpoint.join("/v1/traces")?,
+            rx,
+            resource_attributes,
+            http_headers,
+        );
+
+        thread::Builder::new()
+            .name("OTLP worker".to_string())
+            .spawn(move || {
+                worker.run_loop();
+            })
+            .expect("Spawning worker should not fail");
+
+        Ok(Self { tx })
+    }
+}
+
+impl Telemetry for Otlp {
+    type Visitor = Visitor;
+
+    type TraceId = TraceId;
+
+    type SpanId = SpanId;
+
+    fn mk_visitor(&self) -> Self::Visitor {
+        Default::default()
+    }
+
+    fn report_span(
+        &self,
+        span: tracing_distributed::Span<Self::Visitor, Self::SpanId, Self::TraceId>,
+        events: Vec<tracing_distributed::Event<Self::Visitor, Self::SpanId, Self::TraceId>>,
+    ) {
+        let events = events
+            .into_iter()
+            .map(|ev| span::Event {
+                time_unix_nano: system_time_to_unix_nanos(&ev.initialized_at),
+                name: "event".to_string(),
+                attributes: ev.values.0,
+                dropped_attributes_count: 0,
+            })
+            .collect();
+
+        let span = Span {
+            trace_id: span.trace_id.0.to_le_bytes().to_vec(),
+            span_id: span.id.0.to_le_bytes().to_vec(),
+            trace_state: "".to_string(),
+            parent_span_id: span
+                .parent_id
+                .map(|pid| pid.0.to_le_bytes().to_vec())
+                .unwrap_or_default(),
+            flags: 0,
+            name: span.name,
+            kind: 0,
+            start_time_unix_nano: system_time_to_unix_nanos(&span.initialized_at),
+            end_time_unix_nano: system_time_to_unix_nanos(&span.completed_at),
+            attributes: span.values.0,
+            dropped_attributes_count: 0,
+            events,
+            dropped_events_count: 0,
+            links: vec![],
+            dropped_links_count: 0,
+            status: None,
+        };
+
+        self.tx.send(span).expect("Worker thread should not crash")
+    }
+
+    fn report_event(
+        &self,
+        _event: tracing_distributed::Event<Self::Visitor, Self::SpanId, Self::TraceId>,
+    ) {
+    }
+}
+
+fn system_time_to_unix_nanos(t: &SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| {
+            eprintln!("Time went backwards while calculating OTLP timestamp");
+            Duration::ZERO
+        })
+        .as_nanos() as u64
+}

--- a/tracing-otlp/src/lib.rs
+++ b/tracing-otlp/src/lib.rs
@@ -5,11 +5,11 @@
 use std::{
     str::FromStr,
     sync::mpsc::{channel, Sender},
-    thread::{self},
+    thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use prost::{common::v1::any_value::Value, trace::v1::span};
+use crate::prost::{common::v1::any_value::Value, trace::v1::span};
 use tracing_distributed::{Telemetry, TraceCtxError};
 use url::Url;
 use worker::Worker;

--- a/tracing-otlp/src/lib.rs
+++ b/tracing-otlp/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::prost::{common::v1::any_value::Value, trace::v1::span};
-use tracing_distributed::{Telemetry, TraceCtxError};
+pub use tracing_distributed::{Telemetry, TelemetryLayer, TraceCtxError};
 use url::Url;
 use worker::Worker;
 

--- a/tracing-otlp/src/prost.rs
+++ b/tracing-otlp/src/prost.rs
@@ -1,0 +1,58 @@
+pub mod collector {
+    pub mod trace {
+        pub mod v1 {
+            include!(concat!(
+                env!("OUT_DIR"),
+                "/opentelemetry.proto.collector.trace.v1.rs"
+            ));
+        }
+    }
+}
+
+pub mod common {
+    pub mod v1 {
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/opentelemetry.proto.common.v1.rs"
+        ));
+
+        impl From<String> for any_value::Value {
+            fn from(value: String) -> Self {
+                Self::StringValue(value)
+            }
+        }
+
+        impl From<f64> for any_value::Value {
+            fn from(value: f64) -> Self {
+                Self::DoubleValue(value)
+            }
+        }
+
+        impl From<i64> for any_value::Value {
+            fn from(value: i64) -> Self {
+                Self::IntValue(value)
+            }
+        }
+
+        impl From<bool> for any_value::Value {
+            fn from(value: bool) -> Self {
+                Self::BoolValue(value)
+            }
+        }
+    }
+}
+
+pub mod resource {
+    pub mod v1 {
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/opentelemetry.proto.resource.v1.rs"
+        ));
+    }
+}
+
+pub mod trace {
+    pub mod v1 {
+        include!(concat!(env!("OUT_DIR"), "/opentelemetry.proto.trace.v1.rs"));
+    }
+}

--- a/tracing-otlp/src/visitor.rs
+++ b/tracing-otlp/src/visitor.rs
@@ -1,0 +1,41 @@
+use tracing::field::{Field, Visit};
+
+use crate::prost::common::v1::{any_value::Value, AnyValue, KeyValue};
+
+#[derive(Default, Clone, Debug)]
+pub struct Visitor(pub Vec<KeyValue>);
+
+impl Visit for Visitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0.push(KeyValue::new(
+            field.to_string(),
+            format!("{:?}", value).into(),
+        ))
+    }
+    // TODO: This may allow hashmaps to be used as attributes
+    // fn record_value(&mut self, field: &Field, value: Value<'_>) {
+    //     todo!()
+    // }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.push(KeyValue::new(field.to_string(), value.into()))
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.push(KeyValue::new(field.to_string(), value.into()))
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.0.push(KeyValue::new(field.to_string(), value.into()))
+    }
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0
+            .push(KeyValue::new(field.to_string(), value.to_string().into()))
+    }
+}
+
+impl KeyValue {
+    pub fn new(key: String, value: Value) -> Self {
+        Self {
+            key,
+            value: Some(AnyValue { value: Some(value) }),
+        }
+    }
+}

--- a/tracing-otlp/src/worker.rs
+++ b/tracing-otlp/src/worker.rs
@@ -1,0 +1,137 @@
+use std::{
+    sync::mpsc::{Receiver, RecvTimeoutError},
+    time::{Duration, Instant},
+};
+
+use prost::Message;
+use ureq::Agent;
+use url::Url;
+
+use crate::prost::{
+    collector::trace::v1::{ExportTraceServiceRequest, ExportTraceServiceResponse},
+    common::v1::{any_value::Value, AnyValue, KeyValue},
+    resource::v1::Resource,
+    trace::v1::{ResourceSpans, ScopeSpans, Span},
+};
+
+pub struct Worker {
+    send_interval: Duration,
+    endpoint_trace: Url,
+    rx: Receiver<Span>,
+    resource: Resource,
+    agent: Agent,
+    last_send: Instant,
+    http_headers: Vec<(String, String)>,
+}
+
+impl Worker {
+    pub fn new(
+        send_interval: Duration,
+        endpoint_trace: Url,
+        rx: Receiver<Span>,
+        resource_attributes: Vec<(String, Value)>,
+        http_headers: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            send_interval,
+            endpoint_trace,
+            rx,
+            resource: Resource {
+                attributes: resource_attributes
+                    .into_iter()
+                    .map(|(key, v)| KeyValue {
+                        key,
+                        value: Some(AnyValue { value: v.into() }),
+                    })
+                    .collect(),
+                dropped_attributes_count: 0,
+            },
+            agent: Agent::new(),
+            last_send: Instant::now(),
+            http_headers,
+        }
+    }
+
+    pub fn run_loop(&mut self) {
+        let mut spans = Vec::new();
+        loop {
+            // Receive spans at most until the interval is up
+            match self.rx.recv_timeout(self.duration_to_next_send()) {
+                Ok(span) => spans.push(span),
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+
+            // Send spans on the given interval
+            if self.last_send.elapsed() >= self.send_interval {
+                self.last_send = Instant::now();
+
+                // Only send spans if we have any to send
+                if spans.is_empty() {
+                    continue;
+                }
+
+                let mut protobuf_req = ExportTraceServiceRequest {
+                    resource_spans: vec![ResourceSpans {
+                        resource: Some(self.resource.clone()),
+                        scope_spans: vec![ScopeSpans {
+                            scope: None,
+                            spans: std::mem::take(&mut spans),
+                            schema_url: "".to_string(),
+                        }],
+                        schema_url: "".to_string(),
+                    }],
+                };
+
+                let encoded = protobuf_req.encode_to_vec();
+
+                let mut req = self
+                    .agent
+                    .request_url("POST", &self.endpoint_trace)
+                    .set("Content-Type", "application/x-protobuf");
+
+                // Set the HTTP headers passed by the user
+                req = self.http_headers.iter().fold(req, |r, (k, v)| r.set(k, v));
+                // Send the traces to the server
+                match req.send_bytes(&encoded) {
+                    Ok(res) => {
+                        if let Some("application/x-protobuf") = res.header("content-type") {
+                            let mut buf: Vec<u8> = Vec::new();
+                            if let Err(err) = res.into_reader().read_to_end(&mut buf) {
+                                eprintln!("Protobuf response interrupted: {err}")
+                            }
+                            match ExportTraceServiceResponse::decode(&*buf) {
+                                Ok(res) => {
+                                    if let Some(err) = res.partial_success {
+                                        if !err.error_message.is_empty() || err.rejected_spans != 0
+                                        {
+                                            eprintln!("Server returned protobuf error: {:?}", err)
+                                        }
+                                    }
+                                }
+                                Err(err) => {
+                                    eprintln!("Could not decode protobuf response: {err:?}")
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        // Sending failed, so put spans back into vec
+                        spans = std::mem::take(
+                            &mut protobuf_req.resource_spans[0].scope_spans[0].spans,
+                        );
+                        eprintln!("Error sending spans to {}: {:?}", &self.endpoint_trace, err)
+                    }
+                }
+            }
+        }
+    }
+
+    fn instant_next_send(&self) -> Instant {
+        self.last_send + self.send_interval
+    }
+
+    fn duration_to_next_send(&self) -> Duration {
+        self.instant_next_send() - Instant::now()
+    }
+}

--- a/tracing-otlp/src/worker.rs
+++ b/tracing-otlp/src/worker.rs
@@ -116,10 +116,17 @@ impl Worker {
                         }
                     }
                     Err(err) => {
+                        const MAX_OUTSTANDING: usize = 1024;
+
                         // Sending failed, so put spans back into vec
                         spans = std::mem::take(
                             &mut protobuf_req.resource_spans[0].scope_spans[0].spans,
-                        );
+                        )
+                        .into_iter()
+                        .rev()
+                        .take(MAX_OUTSTANDING)
+                        .rev()
+                        .collect();
                         eprintln!("Error sending spans to {}: {:?}", &self.endpoint_trace, err)
                     }
                 }


### PR DESCRIPTION
This adds a `tracing-distributed`-backed OpenTelemetry implementation. Specifically, this uses the http/protobuf protocol and at the moment only supports OTLP trace messages.

Compared to `tracing-opentelemetry`, this is a much lighter weight implementation as it does not pull in `opentelemetry-sdk` and aims to only support features present in `tracing` and `tracing-distributed`. At the same time, it is more convenient to use for distributed tracing in applications which do not necessarily transmit distributed trace information in headers.